### PR TITLE
Fix regex in BijectionTest

### DIFF
--- a/src/test/java/com/tomgibara/fundament/BijectionTest.java
+++ b/src/test/java/com/tomgibara/fundament/BijectionTest.java
@@ -34,7 +34,7 @@ public class BijectionTest {
 		@Override public boolean isInDomain(Object obj) {
 			if (!(obj instanceof String)) return false;
 			String str = (String) obj;
-			return str.matches("0|(:?[1-9][0-9]*)");
+                       return str.matches("0|(?:[1-9][0-9]*)");
 		}
 		@Override
 		public boolean isInRange(Object obj) {


### PR DESCRIPTION
## Summary
- correct typo in regex used for domain validation

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684d0dbed3b48328aca1aba9a1614983